### PR TITLE
Fixing a typo in Section 6 Part 2

### DIFF
--- a/data/part-6/2-writing-files.md
+++ b/data/part-6/2-writing-files.md
@@ -107,7 +107,7 @@ Hi Ada, we hope you enjoy learning Python with us! Best, Mooc.fi Team
 
 If you want to append data to the end of a file, instead of overwriting the entire file, you should open the file in append mode with the argument `a`.
 
-If the file doesn't yet exist, append mode works exatly like write mode.
+If the file doesn't yet exist, append mode works exactly like write mode.
 
 The following program opens the file `new_file.txt` and appends a couple of lines of text to the end:
 


### PR DESCRIPTION
There is a typo in part-6, section-2 under the "Appending data to an existing file" heading in line no 3. The word is fixed from `exatly` to `exactly`