### PR TITLE
Typo: Fixing a typo in Section 6 Part 3

### DIFF
--- a/data/part-6/3-errors.md
+++ b/data/part-6/3-errors.md
@@ -15,7 +15,7 @@ After this section
 
 </text-box>
 
-The are two basic categories of errors that come up in programming contexts:
+There are two basic categories of errors that come up in programming contexts:
 
 1. Syntax errors, which prevent the execution of the program
 2. Runtime errors, which halt the execution


### PR DESCRIPTION
There is a typo in part 6, section 3 at the beginning of the contents. The word is fixed from `The are` to `There are`