### PR TITLE
Update 4-application-development.md

### DIFF
--- a/data/part-10/4-application-development.md
+++ b/data/part-10/4-application-development.md
@@ -654,8 +654,9 @@ Linnankatu 75, Turku
 
 command: **2**
 name: **Wilhelm**
-address unknown
 number unknown
+address unknown
+
 
 command: **0**
 


### PR DESCRIPTION
In programming exercise "Phone book expansion, version 2", Part 3 the sample output has the following structure:

```
command
name
number information
address information
```

For example, 

```
command: 2
name: Eric
02-123456
Linnankatu 75, Turku
```

However, the very last example has address and number displayed the other way around:

```
command: 2
name: Wilhelm
address unknown
number unknown
```

This PR changes the sample output to be consistent with the previous examples, maintaining a structure of displaying number first, and address second.