### PR TITLE
Fix typo in Part 13 - 4-more-pygame-techniques.md

### DIFF
--- a/data/part-13/4-more-pygame-techniques.md
+++ b/data/part-13/4-more-pygame-techniques.md
@@ -77,7 +77,7 @@ Running the above code should look like this:
 
 Here the method `pygame.font.SysFont` creates a font object, which uses the system font Arial in size 24. The the method `render` creates an image of the specified text in the given colour. This image is drawn on the window with the `blit` method, just as before.
 
-NB: different systems will have different fonts available. If the system this program is exeuted on doesn't have the Arial font, even though Arial is a very common font available on most systems, the default system font is used instead. If you need to have a specific font available for your game, you can include the font file in the game directory and specify its location for the `pygame.font.Font` method.
+NB: different systems will have different fonts available. If the system this program is executed on doesn't have the Arial font, even though Arial is a very common font available on most systems, the default system font is used instead. If you need to have a specific font available for your game, you can include the font file in the game directory and specify its location for the `pygame.font.Font` method.
 
 ## Exercises
 


### PR DESCRIPTION
Typo: "executed" instead of "exeuted "