### PR TITLE
Add missing SSL context argument in retrieve_all() to fix Mac certificate error

### DIFF
--- a/data/part-7/4-data-processing.md
+++ b/data/part-7/4-data-processing.md
@@ -240,7 +240,10 @@ import ssl # add this library to your import section
 
 def retrieve_all():
     # add the following line to the beginning of all your functions
-    context = ssl._create_unverified_context()
+    my_context = ssl._create_unverified_context()
+    address = "https://studies.cs.helsinki.fi/stats-mock/api/courses"
+    # add a second argument to the function call
+    request = urllib.request.urlopen(address, context = my_context)
     # the rest of your function
 ```
 


### PR DESCRIPTION
In the current page, the code only declares the context variable using
context = ssl._create_unverified_context()
but it doesn’t include passing this variable as the second argument to urllib.request.urlopen().
Without adding the context to the function call, the error
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1077)>
still appears on some macOS setups.

This change adds the missing part by including the context parameter in the request call:
request = urllib.request.urlopen(address, context = my_context)
and also defines the address variable for clarity.
This ensures the function actually works as intended and resolves the SSL certificate error on macOS.